### PR TITLE
Updating the Order History page to make its Order cards reusable

### DIFF
--- a/freshly_set/frontend/src/components/pages/profile/OrderHistory.js
+++ b/freshly_set/frontend/src/components/pages/profile/OrderHistory.js
@@ -1,154 +1,27 @@
 import React from 'react';
-import { Link } from "react-router-dom";
+import OrderHistoryCard from './OrderHistoryCard';
+import OrderHistoryList from './json/OrderHistoryList.json'
 
 function OrderHistory() {
+  //Number of Times a Client made Orders
+  const OrdersMade = 4;
   return (
-    <div className="ORDER">
-      
-      {/* Main heading "Your Order History" inside the rounded container */}
-      <h1 className="text-center  font-inter text-[#008000] mb-4">Your Order History</h1>
-       {/*Back button */}
-       <Link to="/" className="BackButton flex justify-start  ">
-              <img src="/static/media/image10.png" alt="" className="m-[10px] lg:m-[6px] w-[30px] lg:w-[50px]"/>
-          </Link>
-
-{/* {first order} */}
-      <div className="w-[365px] lg:w-[905px] mx-0 mr-17 mt-[50px] lg:h-[206.72px]  h-[180px] rounded-[24px] flex flex-col overflow-hidden shadow-md border-4 p-4 bg-white">
-
-      {/* "Delivered" as heading inside the rounded container */}
-      <div className="w-full text-center mb-2">
-        <h2 className="text-lg font-inter text-[#008000]">DELIVERED</h2>
-      </div>
-
-      <div className="w-full flex justify-between items-center">
-        {/* Start with the image and paragraph beside it */}
-        <div className="flex items-start">
-          <img src="/static/media/Frame 324.png" alt="Frame 324" className="w-[120px] h-auto flex-shrink-0" />
-          <div className="ml-4">
-            <p className="text-lg font-inter ">Lettuce</p>
-            <p className="text-sm text-gray-500">3 Bunches</p>
-            <p className="text-sm  text-black">30TH SEP 2024</p>
-          </div>
+    <div className="OrderHistory pb-[50px]">
+      <div className='OrderHistoryWrapper mr-[60px]'>
+        {/*Page Heading */}
+        <div className='Heading'>
+          <h2 className='text-start text-[22px] text-[#008000] font-inter font-[700] my-0'>Your Order History</h2>
         </div>
 
-        {/* Image at the end and button below it */}
-        <div className="flex flex-col items-center ml-4">
-          <img src="/static/media/Group 370.png" alt="Group 370" className="w-[100px] h-auto mb-2" />
-          <button className="ReorderButton cursor-pointer font-inter font-[700] text-white text-[16px] lg:text-[30px] bg-[#008000] w-full py-[8px] rounded-[12px] px-[10px] my-0 border-none active:scale-90 transition-all duration-100 ease-out">RE-ORDER</button>
-        </div>
-      </div>
-      </div>
+        {/*Order Cards */}
+        <div className='OrderCards'>
+          {OrderHistoryList.slice(0, OrdersMade).map((OrderHistoryList) =>
+          <OrderHistoryCard img={OrderHistoryList.img} CropOrdered={OrderHistoryList.CropOrdered} QuantityOrdered={OrderHistoryList.QuantityOrdered} DateOrdered={OrderHistoryList.DateOrdered} OrderStatus={OrderHistoryList.OrderStatus} OrderAmount={OrderHistoryList.OrderAmount}/>
+          )}
+        </div> {/*Order Cards */}
 
-
-{/* {second order} */}
-      <div className="w-[365px] lg:w-[905px] mx-0 mr-17 mt-[50px] lg:h-[206.72px]  h-[180px] rounded-[24px] flex flex-col overflow-hidden shadow-md border-4 p-4 bg-white">
-
-{/* "Delivered" as heading inside the rounded container */}
-<div className="w-full text-center mb-2">
-  <h2 className="text-lg font-inter text-[#008000]">DELIVERED</h2>
-</div>
-
-<div className="w-full flex justify-between items-center">
-  {/* Start with the image and paragraph beside it */}
-  <div className="flex items-start">
-    <img src="/static/media/Frame 324.png" alt="Frame 324" className="w-[120px] h-auto flex-shrink-0" />
-    <div className="ml-4">
-      <p className="text-lg font-inter  text-black">Lettuce</p>
-      <p className="text-sm text-gray-500">3 Bunches</p>
-      <p className="text-sm  text-black">30TH SEP 2024</p>
-    </div>
-  </div>
-
-  {/* Image at the end and button below it */}
-  <div className="flex flex-col items-center ml-4">
-    <img src="/static/media/Group 370.png" alt="Group 370" className="w-[100px] h-auto mb-2" />
-    <button className="ReorderButton cursor-pointer font-inter font-[700] text-white text-[16px] lg:text-[30px] bg-[#008000] w-full py-[8px] rounded-[12px] px-[10px] my-0 border-none active:scale-90 transition-all duration-100 ease-out">RE-ORDER</button>
-  </div>
-</div>
-</div>
-
-{/* {third order} */}
-<div className="w-[365px] lg:w-[905px] mx-0 mr-17 mt-[50px] lg:h-[206.72px]  h-[180px] rounded-[24px] flex flex-col overflow-hidden shadow-md border-4 p-4 bg-white">
-
-{/* "Delivered" as heading inside the rounded container */}
-<div className="w-full text-center mb-2">
-  <h2 className="text-lg font-inter text-[#008000]">DELIVERED</h2>
-</div>
-
-<div className="w-full flex justify-between items-center">
-  {/* Start with the image and paragraph beside it */}
-  <div className="flex items-start">
-    <img src="/static/media/Frame 324.png" alt="Frame 324" className="w-[120px] h-auto flex-shrink-0" />
-    <div className="ml-4">
-      <p className="text-lg font-inter text-black">Lettuce</p>
-      <p className="text-sm text-gray-500">3 Bunches</p>
-      <p className="text-sm   text-black">30TH SEP 2024</p>
-    </div>
-  </div>
-
-  {/* Image at the end and button below it */}
-  <div className="flex flex-col items-center ml-4">
-    <img src="/static/media/Group 370.png" alt="Group 370" className="w-[100px] h-auto mb-2" />
-    <button className="ReorderButton cursor-pointer font-inter font-[700] text-white text-[16px] lg:text-[30px] bg-[#008000] w-full py-[8px] rounded-[12px] px-[10px] my-0 border-none active:scale-90 transition-all duration-100 ease-out">RE-ORDER</button>
-  </div>
-</div>
-</div>
-
-
-{/* {forth order} */}
-<div className="w-[365px] lg:w-[905px] mx-0 mr-17 mt-[50px] lg:h-[206.72px]  h-[180px] rounded-[24px] flex flex-col overflow-hidden shadow-md border-4 p-4 bg-white">
-
-{/* "Delivered" as heading inside the rounded container */}
-<div className="w-full text-center mb-2">
-  <h2 className="text-lg font-inter text-[#008000]">DELIVERED</h2>
-</div>
-
-<div className="w-full flex justify-between items-center">
-  {/* Start with the image and paragraph beside it */}
-  <div className="flex items-start">
-    <img src="/static/media/Frame 324.png" alt="Frame 324" className="w-[120px] h-auto flex-shrink-0" />
-    <div className="ml-4">
-      <p className="text-lg font-inter  text-black">Lettuce</p>
-      <p className="text-sm text-gray-500">3 Bunches</p>
-      <p className="text-sm  text-black">30TH SEP 2024</p>
-    </div>
-  </div>
-
-  {/* Image at the end and button below it */}
-  <div className="flex flex-col items-center ml-4">
-    <img src="/static/media/Group 370.png" alt="Group 370" className="w-[100px] h-auto mb-2" />
-    <button className="ReorderButton cursor-pointer font-inter font-[700] text-white text-[16px] lg:text-[30px] bg-[#008000] w-full py-[8px] rounded-[12px] px-[10px] my-0 border-none active:scale-90 transition-all duration-100 ease-out">RE-ORDER</button>
-  </div>
-</div>
-</div>
-
-{/* {fith order} */}
-<div className="w-[365px] lg:w-[905px] mx-0 mr-17 mt-[50px] lg:h-[206.72px]  h-[180px] rounded-[24px] flex flex-col overflow-hidden shadow-md border-4 p-4 bg-white">
-
-{/* "Delivered" as heading inside the rounded container */}
-<div className="w-full text-center mb-2">
-  <h2 className="text-lg font-inter text-[#008000]">DELIVERED</h2>
-</div>
-
-<div className="w-full flex justify-between items-center">
-  {/* Start with the image and paragraph beside it */}
-  <div className="flex items-start">
-    <img src="/static/media/Frame 324.png" alt="Frame 324" className="w-[120px] h-auto flex-shrink-0" />
-    <div className="ml-4">
-      <p className="text-lg font-inter  text-black">Lettuce</p>
-      <p className="text-sm text-gray-500">3 Bunches</p>
-      <p className="text-sm  text-black">30TH SEP 2024</p>
-    </div>
-  </div>
-
-  {/* Image at the end and button below it */}
-  <div className="flex flex-col items-center ml-4">
-    <img src="/static/media/Group 370.png" alt="Group 370" className="w-[100px] h-auto mb-2" />
-    <button className="ReorderButton cursor-pointer font-inter font-[700] text-white text-[16px] lg:text-[30px] bg-[#008000] w-full py-[8px] rounded-[12px] px-[10px] my-0 border-none active:scale-90 transition-all duration-100 ease-out">RE-ORDER</button>
-  </div>
-</div>
-</div>
-    </div>
+      </div> {/*Order History Wrapper */} 
+    </div> //Order History
   );
 }
 

--- a/freshly_set/frontend/src/components/pages/profile/OrderHistoryCard.js
+++ b/freshly_set/frontend/src/components/pages/profile/OrderHistoryCard.js
@@ -1,0 +1,72 @@
+import React from "react";
+import { Link } from "react-router-dom";
+
+function OrderHistoryCard({img, CropOrdered, QuantityOrdered, DateOrdered, OrderStatus, OrderAmount }) {
+    return (
+        <div className="OrderHistoryCard mt-[40px]">
+            <div className="OrderCardWrapper rounded-[27px] px-[28px] py-[30px] border-solid border-[0.7px] border-[#0000004A] shadow-md shadow-[#00000040] ">
+                <div className="InnerContents flex justify-between">
+                    {/*Product Ordered */}
+                    <div className="ProductOrdered block">
+                        <div className="InnerWrapper flex justify-start">
+                            {/*Crop Card */}
+                            <div className="CropCard block bg-[#00AA5B1A] shadow-md shadow-[#00000040] mr-[40px] rounded-[7.5px] px-[20px] py-[30px] ">
+                                {/*Crop Image */}
+                                <div className="ImageWrapper h-[72px] w-[86px]">
+                                    <img src={img} alt={CropOrdered} className="w-full h-full"/>
+                                </div>
+                            </div>   {/*Crop Card */}
+
+                            {/*Crop descriptions */}
+                            <div className="CropDescriptions block">
+                                {/*Crop Name */}
+                                <div className="CropName">
+                                    <p className="text-start text-[18px] text-[#000000] font-inter font-[700] my-0">{CropOrdered}</p>
+                                </div>
+                                {/*Quantity Ordered */}
+                                <div className="QuantityOrdered mt-[20px]">
+                                    <p className="text-start text-[18px] text-[#0000008F] font-inter font-[700] my-0">{QuantityOrdered}</p>
+                                </div>
+                                {/*Date Ordered */}
+                                <div className="DateOdered mt-[46px]">
+                                    <p className="text-start text-[18px] text-[#000000B2] font-inter font-[700] my-0">{DateOrdered}</p>
+                                </div>
+                            </div>  {/*Crop descriptions */}
+                        </div>  {/*InnerWrapper */}
+                    </div>  {/*Product Ordered */}
+
+                    {/*Order Status */}
+                    <div className="OrderStatus block">
+                        <p className={`${OrderStatus === "Delivered"? "text-[#008000]":OrderStatus === "Packaging"? "text-[#000000]": "text-[#FF0C1A]"} text-center text-[18px] font-inter font-[900] my-0`}>{OrderStatus}</p>
+                    </div>
+
+                    {/*Amount Ordered */}
+                    <div className="AmountOrdered block mx-[60px]">
+                        {/*SubTotal */}
+                        <div className="SubTotal">
+                            {/*Heading */}
+                            <div className="Heading">
+                                <p className="text-center text-[16px] text-[#0000008F] font-inter font-[600] my-0">SubTotal</p>
+                            </div>
+                            {/*Amount */}
+                            <div className="Amount mt-[20px]">
+                                <p className="text-center text-[16px] text-[#FF0C1A] font-inter font-[900] my-0">{OrderAmount}</p>
+                            </div>
+                        </div>
+
+                        {/*Reorder Button */}
+                        <div className="ReorderButton mt-[39px] rounded-[6px] cursor-pointer bg-[#008000] active:scale-90 transition-all duration-300 ease-out">
+                            <Link to="/checkout" className=" ">
+                                <p className="text-center text-[18px] text-[#FFFFFF] font-inter font-[900] px-[24px] py-[6px] my-0">REORDER</p>
+                            </Link>
+                        </div>
+                        
+                    </div>  {/*Amount Ordered */}
+                    
+                </div> {/*Inner Contents */}
+            </div> {/*Order Card Wrapper */}
+        </div> // Order History Card
+    )
+}
+
+export default OrderHistoryCard

--- a/freshly_set/frontend/src/components/pages/profile/json/OrderHistoryList.json
+++ b/freshly_set/frontend/src/components/pages/profile/json/OrderHistoryList.json
@@ -1,0 +1,92 @@
+[
+    {
+        "id": "1",
+        "img": "/static/media/cartItem.png",
+        "CropOrdered": "Lettuce",
+        "QuantityOrdered": "3 Bunches",
+        "DateOrdered": "30TH SEPTMBER 2024",
+        "OrderStatus": "Delivered",
+        "OrderAmount": "KSH 120"
+    },
+     {
+        "id": "2",
+        "img": "/static/media/cartItem.png",
+        "CropOrdered": "Lettuce",
+        "QuantityOrdered": "3 Bunches",
+        "DateOrdered": "30TH SEPTMBER 2024",
+        "OrderStatus": "Delivered",
+        "OrderAmount": "KSH 100"
+    },
+     {
+        "id": "3",
+        "img": "/static/media/cartItem.png",
+        "CropOrdered": "Lettuce",
+        "QuantityOrdered": "8 Bunches",
+        "DateOrdered": "30TH MAY 2024",
+        "OrderStatus": "Delivered",
+        "OrderAmount": "KSH 920"
+    },
+     {
+        "id": "4",
+        "img": "/static/media/cartItem.png",
+        "CropOrdered": "Lettuce",
+        "QuantityOrdered": "6 Bunches",
+        "DateOrdered": "21ST AUGUST 2024",
+        "OrderStatus": "Delivered",
+        "OrderAmount": "KSH 7120"
+    },
+     {
+        "id": "5",
+        "img": "/static/media/cloves.png",
+        "CropOrdered": "Cloves",
+        "QuantityOrdered": "8 Bunches",
+        "DateOrdered": "30TH SEPTMBER 2024",
+        "OrderStatus": "Packaging",
+        "OrderAmount": "KSH 180"
+    },
+     {
+        "id": "6",
+        "img": "/static/media/cartItem.png",
+        "CropOrdered": "Lettuce",
+        "QuantityOrdered": "12 Bunches",
+        "DateOrdered": "30TH SEPTMBER 2024",
+        "OrderStatus": "Processing",
+        "OrderAmount": "KSH 430"
+    },
+     {
+        "id": "7",
+        "img": "/static/media/garlic.png",
+        "CropOrdered": "Garlic",
+        "QuantityOrdered": "20 Bunches",
+        "DateOrdered": "30TH SEPTMBER 2024",
+        "OrderStatus": "Delivered",
+        "OrderAmount": "KSH 500"
+    },
+     {
+        "id": "8",
+        "img": "/static/media/cartItem.png",
+        "CropOrdered": "Lettuce",
+        "QuantityOrdered": "14 Bunches",
+        "DateOrdered": "30TH SEPTMBER 2024",
+        "OrderStatus": "Delivered",
+        "OrderAmount": "KSH 1120"
+    },
+     {
+        "id": "9",
+        "img": "/static/media/c-1.png",
+        "CropOrdered": "Friuts",
+        "QuantityOrdered": "5 Types",
+        "DateOrdered": "27TH SEPTMBER 2024",
+        "OrderStatus": "Packaging",
+        "OrderAmount": "KSH 1200"
+    },
+     {
+        "id": "10",
+        "img": "/static/media/cartItem.png",
+        "CropOrdered": "Lettuce",
+        "QuantityOrdered": "30 Bunches",
+        "DateOrdered": "10TH SEPTMBER 2024",
+        "OrderStatus": "Processing",
+        "OrderAmount": "KSH 320"
+    }
+]


### PR DESCRIPTION
I have updated the Order History Section of the Profile Page to make the order cards reusable

What has been implemented

- Updating the page to fetch the data from the json file dynamically
- Dynamically returning the order progress color , **Black** for **Packaging**:  **Red** for **Packaging** and **Green** for **Delivered** orders

What is left:

- Backend intergration to process the real data for orders the user has made