### PR TITLE
Updated teams section Desktop ad Mobile

### DIFF
--- a/freshly_set/frontend/src/App.js
+++ b/freshly_set/frontend/src/App.js
@@ -17,8 +17,8 @@ import Categories from './components/pages/farm-produce/Categories';
 import FaqDetails from './components/pages/cta-detail/FaqDetails';
 import HeroDetail from './components/pages/cta-detail/HeroDetail';
 import Detailed from './components/pages/homepage/Detailed';
+import TeamDetailed from './components/pages/about-us/TeamDetailed';
 import Detail from './components/pages/about-us/Detail';
-import Details from './components/pages/about-us/Details';
 import TestimonialsDetails from './components/pages/cta-detail/TestimonialsDetails';
 import BlogsAllUpdates from "./components/pages/cta-detail/BlogsAllUpdates"
 import Transporters from './components/pages/cta-detail/Transporters';
@@ -64,7 +64,7 @@ function App() {
         <Route path="/whychoose-detail" element={<Detail />} />
         <Route path="/reviews2-detailed" element={<Detailed />} />
         <Route path="/team-detail" element={<Detailed />} />
-        <Route path="/details" element={<Details />} />
+        <Route path="/team-detailed" element={<TeamDetailed />} />
 
         <Route path="/products/farmingSystems" element={<FarmingSystemsDetail />}/>
         <Route path="/products/gardenSetups" element={<GardenSetupsDetail />} />

--- a/freshly_set/frontend/src/App.js
+++ b/freshly_set/frontend/src/App.js
@@ -63,7 +63,6 @@ function App() {
         <Route path="/about-us" element={<About />} />
         <Route path="/whychoose-detail" element={<WhyChooseDetailed />} />
         <Route path="/reviews2-detailed" element={<Detailed />} />
-        <Route path="/team-detail" element={<Detailed />} />
         <Route path="/team-detailed" element={<TeamDetailed />} />
 
         <Route path="/products/farmingSystems" element={<FarmingSystemsDetail />}/>

--- a/freshly_set/frontend/src/App.js
+++ b/freshly_set/frontend/src/App.js
@@ -18,7 +18,7 @@ import FaqDetails from './components/pages/cta-detail/FaqDetails';
 import HeroDetail from './components/pages/cta-detail/HeroDetail';
 import Detailed from './components/pages/homepage/Detailed';
 import TeamDetailed from './components/pages/about-us/TeamDetailed';
-import Detail from './components/pages/about-us/Detail';
+import WhyChooseDetailed from './components/pages/about-us/WhyChooseDetailed';
 import TestimonialsDetails from './components/pages/cta-detail/TestimonialsDetails';
 import BlogsAllUpdates from "./components/pages/cta-detail/BlogsAllUpdates"
 import Transporters from './components/pages/cta-detail/Transporters';
@@ -61,7 +61,7 @@ function App() {
         <Route path="/marketplace" element={<Products />} />
         <Route path="/products/categories" element={<Categories />} />
         <Route path="/about-us" element={<About />} />
-        <Route path="/whychoose-detail" element={<Detail />} />
+        <Route path="/whychoose-detail" element={<WhyChooseDetailed />} />
         <Route path="/reviews2-detailed" element={<Detailed />} />
         <Route path="/team-detail" element={<Detailed />} />
         <Route path="/team-detailed" element={<TeamDetailed />} />

--- a/freshly_set/frontend/src/components/pages/about-us/Team.js
+++ b/freshly_set/frontend/src/components/pages/about-us/Team.js
@@ -25,7 +25,7 @@ function Team() {
       </div>
 
       {/*View All Button*/}
-      <Link to="/details" className='ViewAll block mt-[30px] lg:mt-[40px] bg-[#008000] w-fit mx-auto rounded-[10px] lg:rounded-[15px]'>
+      <Link to="/team-detailed" className='ViewAll block mt-[30px] lg:mt-[40px] bg-[#008000] w-fit mx-auto rounded-[10px] lg:rounded-[15px]'>
         <p className='text-center text-[12px] lg:text-[25px] text-[#FFFFFF] font-[700] font-inter my-0 py-[12px] px-[40px] '>View All</p>
       </Link>
        

--- a/freshly_set/frontend/src/components/pages/about-us/Team.js
+++ b/freshly_set/frontend/src/components/pages/about-us/Team.js
@@ -1,156 +1,36 @@
 import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
+import TeamCard from './TeamCard';
+import TestimonialsData from './json/TestimonialsData.json'
+import TeamsData from './json/TeamsData.json'
 
 function Team() {
-  const [showAll, setShowAll] = useState(false);
-  const [hoveredMember, setHoveredMember] = useState(null);
-
-  const teamMembers = [
-    { name: 'Malaika Muchiri', role: 'Chief Executive Officer', testimonial: "Freshly Farm's expertise has empowered our local farmers, improving the quality and quantity of our community garden's harvests." },
-    { name: 'Malaika Muchiri', role: 'Chief Executive Officer', testimonial: "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua." },
-    { name: 'Malaika Muchiri', role: 'Chief Executive Officer', testimonial: "Freshly Farm's expertise has empowered our local farmers, improving the quality and quantity of our community garden's harvests." },
-    { name: 'Malaika Muchiri', role: 'Finance Team Member', testimonial: "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua." },
-    { name: 'Malaika Muchiri', role: 'Finance Team Member', testimonial: "Freshly Farm's expertise has empowered our local farmers, improving the quality and quantity of our community garden's harvests." },
-    { name: 'Malaika Muchiri', role: 'Tech Team Member', testimonial: "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua." },
-    { name: 'Malaika Muchiri', role: 'Tech Team Member', testimonial: "Freshly Farm's expertise has empowered our local farmers, improving the quality and quantity of our community garden's harvests." },
-    { name: 'Malaika Muchiri', role: 'Tech Team Member', testimonial: "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua." },
-    { name: 'Malaika Muchiri', role: 'Tech Team Member', testimonial: "Freshly Farm's expertise has empowered our local farmers, improving the quality and quantity of our community garden's harvests." },
-    { name: 'Malaika Muchiri', role: 'Tech Team Member', testimonial: "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua." },
-    { name: 'Malaika Muchiri', role: 'Tech Team Member', testimonial: "Freshly Farm's expertise has empowered our local farmers, improving the quality and quantity of our community garden's harvests." },
-    { name: 'Malaika Muchiri', role: 'Sales Team Member', testimonial: "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua." }
-  ];
-
-  // Group members by role
-  const groupedMembers = teamMembers.reduce((acc, member) => {
-    if (!acc[member.role]) {
-      acc[member.role] = [];
-    }
-    acc[member.role].push(member);
-    return acc;
-  }, {});
-
-  const renderMembers = (members) => (
-    members.map((member, index) => (
-      <div
-        key={index}
-        className="block mx-auto w-[204px] space-y-[12px] relative group"
-        onMouseEnter={() => setHoveredMember(index)}
-        onMouseLeave={() => setHoveredMember(null)}
-      >
-        {/* Testimonial */}
-        <p className='text-black text-[16px] font-[300] w-[199px] font-josefin leading-[20.8px] text-start mb-[10px]'>
-          {member.testimonial}
-        </p>
-        {/* Image */}
-        <div
-          className={`w-[286px] h-[380px] gap-[10px] border-radius-[12px] flex-shrink-0 border-[#008000] transition-all duration-500 ${hoveredMember === index ? 'filter-none' : 'filter grayscale'}`}
-          style={{ backgroundImage: "url('/static/media/teamMember2.png')" }}
-        ></div>
-        {/* Name */}
-        <p className='text-black text-[24px] font-[700] font-inter'>{member.name}</p>
-        {/* Role */}
-        <p className='text-[#008000] text-[20px] font-[700] font-inter'>{member.role}</p>
-        {/* Link Button */}
-        {hoveredMember === index && (
-          <div className="absolute bottom-4 left-1/2 transform -translate-x-1/2">
-            <button className="w-[120px] h-[40px] bg-[#008000] rounded-[8px] text-white text-[14px] border-none flex items-center justify-center">
-              <img src="/path/to/linkedin-icon.png" alt="LinkedIn" className="w-[20px] h-[20px] mr-[5px]" />
-              View Profile
-            </button>
-          </div>
-        )}
-      </div>
-    ))
-  );
-
-  const renderGroupSection = (title, role, count, reverse = false) => (
-    <div className={`mt-[71px] ${reverse ? 'lg:flex-row-reverse' : 'lg:flex-row'} flex flex-col lg:flex-row lg:space-x-10`}>
-      <div className="lg:w-1/2">
-        <h6 className="text-[#008000] text-[35px] text-center font-inter mb-[20px]">{title}</h6>
-        <div className={`flex flex-col lg:flex-row lg:space-x-6 ${reverse ? 'lg:flex-row-reverse' : ''}`}>
-          {renderMembers(groupedMembers[role]?.slice(0, count) || [])}
-        </div>
-      </div>
-    </div>
-  );
+  //Cards To Show per Page
+  const CardsNumber = 3;
 
   return (
     <section id="team" className="block mt-[60px] lg:mt-[100px]">
-      <h5 className="text-[#008000] text-[45px] text-center font-inter my-0">
-        Meet Our Team
-      </h5>
-
-      {/* Display first 3 CEOs without testimonials initially */}
-      {!showAll && (
-        <div className="block space-y-[100px] mt-[40px] lg:mt-[60px]">
-              <div className="block lg:flex flex-wrap justify-between w-[100%] space-y-[20px] lg:space-y-[0px]">
-          {groupedMembers['Chief Executive Officer']?.slice(0, 3).map((member, index) => (
-            <Link to="/Details" key={index} className="block cursor-pointer mx-auto w-[204px] space-y-[12px] relative">
-              <div
-                className=" bg-center w-[286px] h-[380px] gap-[10px] border-radius-[12px] flex-shrink-0 border-[#008000] filter grayscale"
-                style={{ backgroundImage: "url('/static/media/teamMember2.png')" }}
-              ></div>
-              <p className='text-black text-[24px] font-[700] font-inter'>{member.name}</p>
-              <p className='text-[#008000] text-[20px] font-[700] font-inter'>{member.role}</p>
-            </Link>
-          ))}
+      <div className='TeamWrapper mx-[40px]'>
+        <div className='TeamHeading'>
+          <h3 className="DesktopTitle hidden lg:block text-[#008000] text-[45px] font-[700] text-center font-inter my-0">Our Team</h3>
+          <h3 className="MobileTitle block lg:hidden text-[#008000] text-[30px] font-[900] text-center font-inter my-0">Meet Our Team</h3>
         </div>
 
-          <div className={showAll ? "block lg:flex flex-wrap justify-between w-[100%] space-y-[20px] lg:space-y-[0px]":"hidden"}>
-            {groupedMembers['Chief Executive Officer']?.slice(0, 3).map((member, index) => (
-              <div key={index} className="block mx-auto w-[204px] space-y-[12px] relative">
-                <div
-                  className=" bg-center w-[286px] h-[380px] gap-[10px] border-radius-[12px] flex-shrink-0 border-[#008000] filter grayscale"
-                  style={{ backgroundImage: "url('/static/media/teamMember2.png')" }}
-                ></div>
-                <p className='text-black text-[24px] font-[700] font-inter'>{member.name}</p>
-                <p className='text-[#008000] text-[20px] font-[700] font-inter'>{member.role}</p>
-              </div>
-            ))}
-          </div>
-        </div>
+      {/*Team cards */}
+      <div className='TeamCards mt-[30px] lg:mt-[20px] mx-auto grid grid-cols-1  lg:grid-cols-3 lg:gap-x-[100px] gap-y-[40px]'>
+          {TeamsData.slice(0, CardsNumber).map((TeamsData) => (
+            <TeamCard name={TeamsData.name} role={TeamsData.role} img={TeamsData.img} LinkedIn={TeamsData.LinkedIn}/>
+          )
       )}
+      </div>
 
-      {/* Display "View All" button only if not showing all */}
-      {!showAll && (
+      {/*View All Button*/}
+      <Link to="/details" className='ViewAll block mt-[30px] lg:mt-[40px] bg-[#008000] w-fit mx-auto rounded-[10px] lg:rounded-[15px]'>
+        <p className='text-center text-[12px] lg:text-[25px] text-[#FFFFFF] font-[700] font-inter my-0 py-[12px] px-[40px] '>View All</p>
+      </Link>
        
-        <div className='flex justify-center mt-[120px]'>
-           <Link to="/Details " className='absolute block  mx-[80px] -mt-[60px] lg:-mt-[180px]'>
-          
-          <button
-            onClick={() => setShowAll(true)}
-            className='w-[272px] cursor-pointer h-[70px] bg-[#008000] rounded-[15px] mt-[40px] text-white text-[25px] border-none'
-          >
-
-
-            View All
-           
-          </button>
-          </Link>
-        </div>
-      )}
-
-      {/* Display all team members in sections with testimonials */}
-      {showAll && (
-        <div
-          className={`transition-transform transform ${showAll ? 'translate-x-0' : 'translate-x-full'} duration-500 ease-in-out`}
-          style={{ opacity: showAll ? 1 : 0 }}
-        >
-          {renderGroupSection('Executive Team', 'Chief Executive Officer', 3)}
-
-          {renderGroupSection('Finance Team', 'Finance Team Member', 2, true)}
-
-          <div className="mt-[71px]">
-            <h6 className="text-[#008000] text-[35px] text-center font-inter mb-[20px] lg:space-y-[0px]">Tech Team</h6>
-            <div className="grid grid-cols-3 gap-6">
-              {renderMembers(groupedMembers['Tech Team Member']?.slice(0, 6) || [])}
-            </div>
-          </div>
-
-          {renderGroupSection('Sales Team', 'Sales Team Member', 1)}
-        </div>
-      )}
-    </section>
+      </div> {/*Teams Wrapper */}
+    </section> //Team
   );
 }
 

--- a/freshly_set/frontend/src/components/pages/about-us/TeamCard.js
+++ b/freshly_set/frontend/src/components/pages/about-us/TeamCard.js
@@ -1,0 +1,54 @@
+import React, { useState } from 'react'
+import { Link } from "react-router-dom";
+
+function TeamCard({ name, img, role, LinkedIn }) {
+    // State to manage color changes
+    const [isHovered, setIsHovered] = useState({id:false});
+
+    // Function to toggle the color and position on mouse enter
+    const toggleColor = (id) => {
+        setIsHovered((prevState) => ({
+          ...prevState,
+          [id]: !prevState[id],
+        }));
+      };
+
+    // Function to toggle the color and position on mouse leave
+    const returnColor = (id) => {
+        setIsHovered((!isHovered));
+      }; 
+
+    return (
+        <div className="TeamCard mx-auto">
+            <div TeamCardWrapper> 
+                <div className={`ImageFrame ${isHovered[1]? "scale-x-105 scale-y-105": ""} transform origin-top-left transition-all duration-300 relative  `}
+                    onMouseEnter={()=>toggleColor(1)}
+                    onMouseLeave={()=>returnColor(1)}
+                >
+                    {/*Member Image */}
+                    <div className={` MemberImage mx-auto ${isHovered[1]? "grayscale-0": "grayscale"} transform transition-all duration-300 w-[165px] lg:w-[286px] h-[220px] lg:h-[380px] `}>
+                    <img src={img} alt={name} className="w-full h-full rounded-[12px]"/>
+                    </div>
+                    {/*LinkedIn Logo */}
+                    <Link to={LinkedIn} target='blank' className={`LinkedIn ${isHovered[1]? "grayscale-0": "hidden"} block delay-300 grayscale  transform transition-all duration-300`}>
+                        <div className="w-[50px] h-[50px]  absolute left-[110px] bottom-[20px]">
+                            <img src="/static/media/linkedinn.png" alt="" className="w-full h-full rounded-[6px]"/>
+                        </div>
+                    </Link>
+                </div>
+
+                {/*Member Name */}
+                <div className="mt-[20px]">
+                    <p className="text-center text-[#000000] text-[20px] lg:text-[24px] font-[700] font-inter my-0 ">{name}</p>
+                </div>
+
+                {/*member Role */}
+                <div className="">
+                    <p className="text-center text-[#008000] text-[16px] lg:text-[20px] font-[700] font-inter my-0 ">{role} </p>
+                </div>
+            </div> {/*TeamCardWrapper */}
+        </div>  //TeamCard
+    )
+}
+
+export default TeamCard

--- a/freshly_set/frontend/src/components/pages/about-us/TeamDetailed.js
+++ b/freshly_set/frontend/src/components/pages/about-us/TeamDetailed.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import Nav from '../../Nav/Navbar';
 
-function Details() {
+function TeamDetailed() {
   return (
     <div>
       <Nav />
@@ -232,4 +232,4 @@ function Details() {
   );
 }
 
-export default Details;
+export default TeamDetailed;

--- a/freshly_set/frontend/src/components/pages/about-us/TeamDetailed.js
+++ b/freshly_set/frontend/src/components/pages/about-us/TeamDetailed.js
@@ -1,234 +1,139 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 import Nav from '../../Nav/Navbar';
+import TeamCard from './TeamCard';
+import TeamsData from './json/TeamsData.json'
+import TeamFinance from './json/TeamFinance.json'
+import TeamTech from './json/TeamTech.json'
+import TeamSales from './json/TeamSales.json'
+
 
 function TeamDetailed() {
+  //Number of Team Member per each category
+  const ExecutiveTeam = 3;
+  const FinanceTeam = 2;
+  const TechTeam = 9;
+  const SalesTeam = 1;
+  
   return (
-    <div>
-      <Nav />
-
-      <div className="block mt-[150px] lg:mt-[200px]">
-
-        {/* {Team 1} */}
-        {/* Executive Team */}
-        <div className="">
-
-          <h3 className="text-[30px] font-inter font-[900] text-[#008000] text-center lg:text-start ml-[150px]">EXECUTIVE TEAM</h3>
-          <p className="text-[#525560] mx-auto font-josfin text-[15px] font-[700] leading-[32.5px] w-[325px] lg:w-[926px] text-start ml-[150px]">
-            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut.
-          </p>
-          <p className="text-[#525560] mx-auto font-josfin text-[15px] font-[700] leading-[32.5px] w-[325px] lg:w-[926px] text-start ml-[150px]">
-            Aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident,
-          </p>
-          <div className="block">
-            <div className="grid grid-cols-2 lg:grid-cols-3 lg:ml-[80px] gap-y-[38px] lg:gap-y-[0px] lg:mt-[100px] mx-auto">
-             
-              <div className="relative block w-[165px] lg:w-[286px] z-30 group">
-                <a href="#" target='_blank'>
-                    <img className="absolute top-[150px] cursor-pointer transition-all duration-500 ease-out left-[120px] z-20 h-[60px] w-[60px] grayscale hidden group-hover:flex" src="/static/media/linkedinn.png"  alt="LinkedInImg"/>
-
-                </a>
-                <img className="h-[232.56px] lg:h-[380px] w-[165px] lg:w-[286px] grayscale hover:grayscale-0 transform transition-all duration-500 cursor-pointer" src="/static/media/teamMember2.png" alt="MeetTeamImg" />
-                <p className="text-[15px] lg:text-[24px] text-black font-inter font-[700] text-center">Malaika Muchiri</p>
-                <p className="text-[12px] lg:text-[20px] text-[#008000] font-inter font-[700] text-center">Chief Executive Officer</p>
-              </div>
-
-               <div className="relative block w-[165px] lg:w-[286px] z-30 group">
-                <a href="#" target='_blank'>
-                    <img className="absolute top-[150px] cursor-pointer transition-all duration-500 ease-out left-[120px] z-20 h-[60px] w-[60px] grayscale hidden group-hover:flex" src="/static/media/linkedinn.png"  alt="LinkedInImg"/>
-
-                </a>
-                <img className="h-[232.56px] lg:h-[380px] w-[165px] lg:w-[286px] grayscale hover:grayscale-0 transform transition-all duration-500 cursor-pointer" src="/static/media/teamMember2.png" alt="MeetTeamImg" />
-                <p className="text-[15px] lg:text-[24px] text-black font-inter font-[700] text-center">Malaika Muchiri</p>
-                <p className="text-[12px] lg:text-[20px] text-[#008000] font-inter font-[700] text-center">Chief Executive Officer</p>
-              </div>
-              <div className="relative block w-[165px] lg:w-[286px] z-30 group">
-                <a href="#" target='_blank'>
-                    <img className="absolute top-[150px] cursor-pointer transition-all duration-500 ease-out left-[120px] z-20 h-[60px] w-[60px] grayscale hidden group-hover:flex" src="/static/media/linkedinn.png"  alt="LinkedInImg"/>
-
-                </a>
-                <img className="h-[232.56px] lg:h-[380px] w-[165px] lg:w-[286px] grayscale hover:grayscale-0 transform transition-all duration-500 cursor-pointer" src="/static/media/teamMember2.png" alt="MeetTeamImg" />
-                <p className="text-[15px] lg:text-[24px] text-black font-inter font-[700] text-center">Malaika Muchiri</p>
-                <p className="text-[12px] lg:text-[20px] text-[#008000] font-inter font-[700] text-center">Chief Executive Officer</p>
-              </div>
-            </div>
-          </div>
-        </div>
-        {/* {Team 2} */}
-        {/* Finance Team */}
-        <div className="mt-[130px] w-[100%]">
-          <div className="flex justify-end lg:pr-[95px]">
-            <div className="block text-right lg:text-right">
-              <h3 className="text-[30px] font-inter font-[900] text-[#008000]">FINANCE TEAM</h3>
-              <p className="text-[#525560] lg:mx-[0px] font-josfin text-[15px] font-[700] leading-[32.5px] w-[325px] lg:w-[926px] text-right ml-[150px]">
-                Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut.
-              </p>
-              <p className="text-[#525560] lg:mx-[0px] font-josfin text-[15px] font-[700] leading-[32.5px] w-[325px] lg:w-[926px] text-right ml-[150px]">
-                Aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident,
-              </p>
-            </div>
-          </div>
-          <div className="flex justify-center w-[100%]">
-            <div className="block">
-              <div className="grid grid-cols-2 lg:grid-cols-2 lg:gap-x-[122px] gap-y-[38px] lg:gap-y-[0px] lg:mt-[100px] mx-auto">
-              <div className="relative block w-[165px] lg:w-[286px] z-30 group">
-                <a href="#" target='_blank'>
-                    <img className="absolute top-[150px] cursor-pointer transition-all duration-500 ease-out left-[120px] z-20 h-[60px] w-[60px] grayscale hidden group-hover:flex" src="/static/media/linkedinn.png"  alt="LinkedInImg"/>
-
-                </a>
-                <img className="h-[232.56px] lg:h-[380px] w-[165px] lg:w-[286px] grayscale hover:grayscale-0 transform transition-all duration-500 cursor-pointer" src="/static/media/teamMember2.png" alt="MeetTeamImg" />
-                <p className="text-[15px] lg:text-[24px] text-black font-inter font-[700] text-center">Malaika Muchiri</p>
-                <p className="text-[12px] lg:text-[20px] text-[#008000] font-inter font-[700] text-center">Chief Executive Officer</p>
-              </div>
-              <div className="relative block w-[165px] lg:w-[286px] z-30 group">
-                <a href="#" target='_blank'>
-                    <img className="absolute top-[150px] cursor-pointer transition-all duration-500 ease-out left-[120px] z-20 h-[60px] w-[60px] grayscale hidden group-hover:flex" src="/static/media/linkedinn.png"  alt="LinkedInImg"/>
-
-                </a>
-                <img className="h-[232.56px] lg:h-[380px] w-[165px] lg:w-[286px] grayscale hover:grayscale-0 transform transition-all duration-500 cursor-pointer" src="/static/media/teamMember2.png" alt="MeetTeamImg" />
-                <p className="text-[15px] lg:text-[24px] text-black font-inter font-[700] text-center">Malaika Muchiri</p>
-                <p className="text-[12px] lg:text-[20px] text-[#008000] font-inter font-[700] text-center">Chief Executive Officer</p>
-              </div>
-              </div>
-            </div>
-          </div>
-        </div>
-         {/* {Team 3} */}
-        {/* Tech Team */}
-        <div className="mt-[150px] w-[100%] lg:mt-[250px]">
-          <div className="block">
-            <h3 className='text-[30px] font-inter font-[900] text-[#008000] text-center lg:text-start ml-[200px]'>TECH TEAM</h3>
-            <p className="text-[#525560] mx-auto font-josfin text-[15px] font-[700] leading-[32.5px] w-[325px] lg:w-[926px] text-start ml-[150px]">
-              Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut.
-            </p>
-            <p className="text-[#525560] mx-auto font-josfin text-[15px] font-[700] leading-[32.5px] w-[325px] lg:w-[926px] text-start ml-[150px]">
-              Aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident,
-            </p>
-          </div>
-          <div className="flex justify-center lg:justify-start mt-[100px]">
-            <div className="grid grid-cols-3 gap-x-[40px] gap-y-[40px] mx-auto">
-              <div className="relative block flex-col items-center w-[165px] lg:w-[286px] space-y-[10px] z-30 group">
-              <a href="#" target='_blank'>
-                    <img className="absolute top-[150px] cursor-pointer transition-all duration-500 ease-out left-[120px] z-20 h-[60px] w-[60px] grayscale hidden group-hover:flex" src="/static/media/linkedinn.png"  alt="LinkedInImg"/>
-
-                </a>
-                <img className="h-[232.56px] lg:h-[380px] w-[165px] lg:w-[286px] grayscale hover:grayscale-0 transform transition-all duration-500 cursor-pointer" src="/static/media/teamMember2.png" alt="MeetTeamImg" />
-                <p className="text-[15px] lg:text-[24px] text-black font-inter font-[700] text-center">Malaika Muchiri</p>
-                <p className="text-[12px] lg:text-[20px] text-[#008000] font-inter font-[700] text-center">Tech Team</p>
-              </div>
-              <div className="relative block flex-col items-center w-[165px] lg:w-[286px] space-y-[10px] z-30 group">
-              <a href="#" target='_blank'>
-                    <img className="absolute top-[150px] cursor-pointer transition-all duration-500 ease-out left-[120px] z-20 h-[60px] w-[60px] grayscale hidden group-hover:flex" src="/static/media/linkedinn.png"  alt="LinkedInImg"/>
-
-                </a>
-                <img className="h-[232.56px] lg:h-[380px] w-[165px] lg:w-[286px] grayscale hover:grayscale-0 transform transition-all duration-500 cursor-pointer" src="/static/media/teamMember2.png" alt="MeetTeamImg" />
-                <p className="text-[15px] lg:text-[24px] text-black font-inter font-[700] text-center">Malaika Muchiri</p>
-                <p className="text-[12px] lg:text-[20px] text-[#008000] font-inter font-[700] text-center">Tech Team</p>
-              </div>
-              <div className="relative block flex-col items-center w-[165px] lg:w-[286px] space-y-[10px] z-30 group">
-              <a href="#" target='_blank'>
-                    <img className="absolute top-[150px] cursor-pointer transition-all duration-500 ease-out left-[120px] z-20 h-[60px] w-[60px] grayscale hidden group-hover:flex" src="/static/media/linkedinn.png"  alt="LinkedInImg"/>
-
-                </a>
-                <img className="h-[232.56px] lg:h-[380px] w-[165px] lg:w-[286px] grayscale hover:grayscale-0 transform transition-all duration-500 cursor-pointer" src="/static/media/teamMember2.png" alt="MeetTeamImg" />
-                <p className="text-[15px] lg:text-[24px] text-black font-inter font-[700] text-center">Malaika Muchiri</p>
-                <p className="text-[12px] lg:text-[20px] text-[#008000] font-inter font-[700] text-center">Tech Team</p>
-              </div>
-              <div className="relative block flex-col items-center w-[165px] lg:w-[286px] space-y-[10px] z-30 group">
-              <a href="#" target='_blank'>
-                    <img className="absolute top-[150px] cursor-pointer transition-all duration-500 ease-out left-[120px] z-20 h-[60px] w-[60px] grayscale hidden group-hover:flex" src="/static/media/linkedinn.png"  alt="LinkedInImg"/>
-
-                </a>
-                <img className="h-[232.56px] lg:h-[380px] w-[165px] lg:w-[286px] grayscale hover:grayscale-0 transform transition-all duration-500 cursor-pointer" src="/static/media/teamMember2.png" alt="MeetTeamImg" />
-                <p className="text-[15px] lg:text-[24px] text-black font-inter font-[700] text-center">Malaika Muchiri</p>
-                <p className="text-[12px] lg:text-[20px] text-[#008000] font-inter font-[700] text-center">Tech Team</p>
-              </div>
-              <div className="relative block flex-col items-center w-[165px] lg:w-[286px] space-y-[10px] z-30 group">
-              <a href="#" target='_blank'>
-                    <img className="absolute top-[150px] cursor-pointer transition-all duration-500 ease-out left-[120px] z-20 h-[60px] w-[60px] grayscale hidden group-hover:flex" src="/static/media/linkedinn.png"  alt="LinkedInImg"/>
-
-                </a>
-                <img className="h-[232.56px] lg:h-[380px] w-[165px] lg:w-[286px] grayscale hover:grayscale-0 transform transition-all duration-500 cursor-pointer" src="/static/media/teamMember2.png" alt="MeetTeamImg" />
-                <p className="text-[15px] lg:text-[24px] text-black font-inter font-[700] text-center">Malaika Muchiri</p>
-                <p className="text-[12px] lg:text-[20px] text-[#008000] font-inter font-[700] text-center">Tech Team</p>
-              </div>
-              <div className="relative block flex-col items-center w-[165px] lg:w-[286px] space-y-[10px] z-30 group">
-              <a href="#" target='_blank'>
-                    <img className="absolute top-[150px] cursor-pointer transition-all duration-500 ease-out left-[120px] z-20 h-[60px] w-[60px] grayscale hidden group-hover:flex" src="/static/media/linkedinn.png"  alt="LinkedInImg"/>
-
-                </a>
-                <img className="h-[232.56px] lg:h-[380px] w-[165px] lg:w-[286px] grayscale hover:grayscale-0 transform transition-all duration-500 cursor-pointer" src="/static/media/teamMember2.png" alt="MeetTeamImg" />
-                <p className="text-[15px] lg:text-[24px] text-black font-inter font-[700] text-center">Malaika Muchiri</p>
-                <p className="text-[12px] lg:text-[20px] text-[#008000] font-inter font-[700] text-center">Tech Team</p>
-              </div>
-              <div className="relative block flex-col items-center w-[165px] lg:w-[286px] space-y-[10px] z-30 group">
-              <a href="#" target='_blank'>
-                    <img className="absolute top-[150px] cursor-pointer transition-all duration-500 ease-out left-[120px] z-20 h-[60px] w-[60px] grayscale hidden group-hover:flex" src="/static/media/linkedinn.png"  alt="LinkedInImg"/>
-
-                </a>
-                <img className="h-[232.56px] lg:h-[380px] w-[165px] lg:w-[286px] grayscale hover:grayscale-0 transform transition-all duration-500 cursor-pointer" src="/static/media/teamMember2.png" alt="MeetTeamImg" />
-                <p className="text-[15px] lg:text-[24px] text-black font-inter font-[700] text-center">Malaika Muchiri</p>
-                <p className="text-[12px] lg:text-[20px] text-[#008000] font-inter font-[700] text-center">Tech Team</p>
-              </div>
-              <div className=" relative block flex-col items-center w-[165px] lg:w-[286px] space-y-[10px] z-30 group">
-
-              <a href="#" target='_blank'>
-                    <img className="absolute top-[150px] cursor-pointer transition-all duration-500 ease-out left-[120px] z-20 h-[60px] w-[60px] grayscale hidden group-hover:flex" src="/static/media/linkedinn.png"  alt="LinkedInImg"/>
-
-                </a>
-                <img className="h-[232.56px] lg:h-[380px] w-[165px] lg:w-[286px] grayscale hover:grayscale-0 transform transition-all duration-500 cursor-pointer" src="/static/media/teamMember2.png" alt="MeetTeamImg" />
-                <p className="text-[15px] lg:text-[24px] text-black font-inter font-[700] text-center">Malaika Muchiri</p>
-                <p className="text-[12px] lg:text-[20px] text-[#008000] font-inter font-[700] text-center">Tech Team</p>
-              </div>
-              <div className="relative block flex-col items-center w-[165px] lg:w-[286px] space-y-[10px] z-30 group">
-              
-                <a href="#" target='_blank'>
-                    <img className="absolute top-[150px] cursor-pointer transition-all duration-500 ease-out left-[120px] z-20 h-[60px] w-[60px] grayscale hidden group-hover:flex" src="/static/media/linkedinn.png"  alt="LinkedInImg"/>
-
-                </a>
-                <img className="h-[232.56px] lg:h-[380px] w-[165px] lg:w-[286px] grayscale hover:grayscale-0 transform transition-all duration-500 cursor-pointer" src="/static/media/teamMember2.png" alt="MeetTeamImg" />
-                <p className="text-[15px] lg:text-[24px] text-black font-inter font-[700] text-center">Malaika Muchiri</p>
-                <p className="text-[12px] lg:text-[20px] text-[#008000] font-inter font-[700] text-center">Tech Team</p>
-              </div>
-            </div>
-          </div>
-        </div>
-        
-
-        {/* {Team 4} */}
-        {/* Sales Team */}
-        <div className="mt-[200px] w-[100%] lg:mt-[300px]">
-          <div className="flex justify-end lg:pr-[95px]">
-            <div className="block text-right lg:text ">
-              <h3 className="text-[30px] font-inter font-[900] text-[#008000]  ">SALES TEAM</h3>
-              
-              <p className="text-[#525560] lg:mx-[0px] font-josfin text-[15px] font-[700] leading-[32.5px] w-[325px] lg:w-[926px] text-right ml-[150px] cd">
-                Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut.
-              </p>
-              <p className="text-[#525560] lg:mx-[0px] font-josfin text-[15px] font-[700] leading-[32.5px] w-[325px] lg:w-[926px] text-right ml-[150px]">
-                Aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident,
-              </p>
-            </div>
-          </div>
-          <div className="flex justify-center w-[100%]">
-  <div className="block">
-    <div className="grid grid-cols-2 lg:grid-cols-2 lg:gap-x-[122px] gap-y-[38px] lg:gap-y-[0px] lg:mt-[100px] mx-auto">
-    <div className="relative block w-[165px] lg:w-[286px] z-30 group">
-                <a href="#" target='_blank'>
-                    <img className="absolute top-[150px] cursor-pointer transition-all duration-500 ease-out left-[120px] z-20 h-[60px] w-[60px] grayscale hidden group-hover:flex" src="/static/media/linkedinn.png"  alt="LinkedInImg"/>
-
-                </a>
-
-        <img className="h-[232.56px] lg:h-[380px] w-[165px] lg:w-[286px] grayscale hover:grayscale-0 transform transition-all duration-500 cursor-pointer" src="/static/media/teamMember2.png" alt="MeetTeamImg" />
-        
-        <p className="text-[15px] lg:text-[24px] text-black font-inter font-[700] text-center">Malaika Muchiri</p>
-        <p className="text-[12px] lg:text-[20px] text-[#008000] font-inter font-[700] text-center">Sales Team</p>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>f
+    <div className='TeamDetailed'>
+      {/*Navbar */}
+      <div className=''>
+        <Nav />
       </div>
-    </div>
+
+      <div className="InnerContents block mx-[12px] lg:mx-[40px] pb-[80px] mt-[150px] lg:mt-[200px]">
+        {/*Back Button */}
+        <div className="BackButton w-fit" >
+          <Link to="/about-us" >
+              <div className="ButtonWrapper w-[61px] h-[47px] cursor-pointer">
+                  <img src="/static/media/image10.png"  alt="BackButton" className="w-full h-full"/>
+              </div>
+          </Link>
+        </div>
+
+        {/*Executive Team */}
+        <div className='ExecutiveTeamWrapper mt-[40px]'>
+          {/*Details */}
+          <div className='ExecutiveTeamDetails ml-[60px] mr-[210px]'>
+            <div className='Heading'>
+              <h3 className='text-start text-[45px] text-[#008000] font-inter font-[900] my-0'>EXECUTIVE TEAM</h3>
+            </div>
+            <div className='Descriptions mt-[20px]'>
+              <p className='text-start text-[20px] text-[#525560] font-josefin font-[700] my-0'>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut.</p>
+            </div>
+            <div className='Descriptions mt-[30px]'>
+              <p className='text-start text-[20px] text-[#525560] font-josefin font-[700] my-0'>Aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident,</p>
+            </div>
+          </div>
+          {/*Executive Team Cards */}
+          <div className='ExecutiveWrapper mt-[30px] lg:mt-[60px] -mx-[40px]'>
+            <div className='TeamCards  mx-auto grid grid-cols-1  lg:grid-cols-3 lg:gap-x-[100px] gap-y-[40px]'>
+              {TeamsData.slice(0, ExecutiveTeam).map((TeamsData) => (
+                <TeamCard name={TeamsData.name} role={TeamsData.role} img={TeamsData.img} LinkedIn={TeamsData.LinkedIn}/>
+                  )
+                )}
+            </div>
+          </div>
+        </div> {/*Executive Team */}
+
+        {/*Finance Team */}
+        <div className='FinanceTeamWrapper mt-[100px]'>
+          {/*Details */}
+          <div className='FinanceTeamDetails ml-[210px] mr-[60px]'>
+            <div className='Heading'>
+              <h3 className='text-right text-[45px] text-[#008000] font-inter font-[900] my-0'>FINANCE TEAM TEAM</h3>
+            </div>
+            <div className='Descriptions mt-[20px]'>
+              <p className='text-right text-[20px] text-[#525560] font-josefin font-[700] my-0'>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut.</p>
+            </div>
+            <div className='Descriptions mt-[30px]'>
+              <p className='text-right text-[20px] text-[#525560] font-josefin font-[700] my-0'>Aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident,</p>
+            </div>
+          </div>
+          {/*Finance Team Cards */}
+          <div className='FinanceWrapper mt-[30px] lg:mt-[60px] mx-[200px]'>
+            <div className='TeamCards  mx-auto flex justify-center lg:gap-x-[100px] gap-y-[40px]'>
+              {TeamFinance.slice(0, FinanceTeam).map((TeamFinance) => (
+                <TeamCard name={TeamFinance.name} role={TeamFinance.role} img={TeamFinance.img} LinkedIn={TeamFinance.LinkedIn}/>
+                  )
+                )}
+            </div>
+          </div>
+        </div> {/*Finance Team */}
+
+        {/*Tech Team */}
+        <div className='TechTeamWrapper mt-[100px]'>
+          {/*Details */}
+          <div className='TechTeamDetails ml-[60px] mr-[210px]'>
+            <div className='Heading'>
+              <h3 className='text-start text-[45px] text-[#008000] font-inter font-[900] my-0'>TECH TEAM</h3>
+            </div>
+            <div className='Descriptions mt-[20px]'>
+              <p className='text-start text-[20px] text-[#525560] font-josefin font-[700] my-0'>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut.</p>
+            </div>
+            <div className='Descriptions mt-[30px]'>
+              <p className='text-start text-[20px] text-[#525560] font-josefin font-[700] my-0'>Aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident,</p>
+            </div>
+          </div>
+          {/*Tech Team Cards */}
+          <div className='TechWrapper mt-[30px] lg:mt-[60px] -mx-[40px]'>
+            <div className='TeamCards  mx-auto grid grid-cols-1  lg:grid-cols-3 lg:gap-x-[100px] gap-y-[40px]'>
+              {TeamTech.slice(0, TechTeam).map((TeamTech) => (
+                <TeamCard name={TeamTech.name} role={TeamTech.role} img={TeamTech.img} LinkedIn={TeamTech.LinkedIn}/>
+                  )
+                )}
+            </div>
+          </div>
+        </div> {/*Tech Team */}
+
+        {/*Sales Team */}
+        <div className='SalesTeamWrapper mt-[100px]'>
+          {/*Details */}
+          <div className='SalesTeamDetails ml-[210px] mr-[60px]'>
+            <div className='Heading'>
+              <h3 className='text-right text-[45px] text-[#008000] font-inter font-[900] my-0'>SALES TEAM</h3>
+            </div>
+            <div className='Descriptions mt-[20px]'>
+              <p className='text-right text-[20px] text-[#525560] font-josefin font-[700] my-0'>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut.</p>
+            </div>
+            <div className='Descriptions mt-[30px]'>
+              <p className='text-right text-[20px] text-[#525560] font-josefin font-[700] my-0'>Aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident,</p>
+            </div>
+          </div>
+          {/*Sales Team Cards */}
+          <div className='SalesWrapper mt-[30px] lg:mt-[60px] -mx-[40px]'>
+            <div className='TeamCards  mx-auto flex justify-center lg:gap-x-[100px] gap-y-[40px]'>
+              {TeamSales.slice(0, SalesTeam).map((TeamSales) => (
+                <TeamCard name={TeamSales.name} role={TeamSales.role} img={TeamSales.img} LinkedIn={TeamSales.LinkedIn}/>
+                  )
+                )}
+            </div>
+          </div>
+        </div> {/*Sales Team */}
+
+      </div> {/*Inner Contents */}
+    </div> // Team detailed
   );
 }
 

--- a/freshly_set/frontend/src/components/pages/about-us/WhyChooseDetailed.js
+++ b/freshly_set/frontend/src/components/pages/about-us/WhyChooseDetailed.js
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import Nav from '../../Nav/Navbar';
 import { Link } from 'react-router-dom';
 
-function Detail() {
+function WhyChooseDetailed() {
     const [selectedSection, setSelectedSection] = useState("technologyFarming")
   return (
     <div className="AllPageContent">
@@ -390,4 +390,4 @@ function Detail() {
   );
 }
 
-export default Detail;
+export default WhyChooseDetailed;

--- a/freshly_set/frontend/src/components/pages/about-us/json/TeamFinance.json
+++ b/freshly_set/frontend/src/components/pages/about-us/json/TeamFinance.json
@@ -1,0 +1,16 @@
+[
+    {
+        "id": "1",
+        "name": "Malaika Muchiri",
+        "img": "/static/media/teamMember2.png",
+        "LinkedIn": "https://www.linkedin.com/in/kimberly-kelsy-926259307",
+        "role": "Finance Team"
+    },
+    {
+        "id": "2",
+        "name": "Malaika Muchiri",
+        "img": "/static/media/teamMember2.png",
+        "LinkedIn": "https://www.linkedin.com/in/kimberly-kelsy-926259307",
+        "role": "Finance Team"
+    }   
+]

--- a/freshly_set/frontend/src/components/pages/about-us/json/TeamSales.json
+++ b/freshly_set/frontend/src/components/pages/about-us/json/TeamSales.json
@@ -1,0 +1,9 @@
+[
+    {
+        "id": "1",
+        "name": "Malaika Muchiri",
+        "img": "/static/media/teamMember2.png",
+        "LinkedIn": "https://www.linkedin.com/in/kimberly-kelsy-926259307",
+        "role": "Sales Team"
+    }
+]

--- a/freshly_set/frontend/src/components/pages/about-us/json/TeamTech.json
+++ b/freshly_set/frontend/src/components/pages/about-us/json/TeamTech.json
@@ -1,0 +1,65 @@
+[
+    {
+        "id": "1",
+        "name": "Malaika Muchiri",
+        "img": "/static/media/teamMember2.png",
+        "LinkedIn": "https://www.linkedin.com/in/kimberly-kelsy-926259307",
+        "role": "Tech Team"
+    },
+    {
+        "id": "2",
+        "name": "Malaika Muchiri",
+        "img": "/static/media/teamMember2.png",
+        "LinkedIn": "https://www.linkedin.com/in/kimberly-kelsy-926259307",
+        "role": "Tech Team"
+    },
+    {
+        "id": "3",
+        "name": "Malaika Muchiri",
+        "img": "/static/media/teamMember2.png",
+        "LinkedIn": "https://www.linkedin.com/in/kimberly-kelsy-926259307",
+        "role": "Tech Team"
+    },
+    {
+        "id": "4",
+        "name": "Malaika Muchiri",
+        "img": "/static/media/teamMember2.png",
+        "LinkedIn": "https://www.linkedin.com/in/kimberly-kelsy-926259307",
+        "role": "Tech Team"
+    },
+    {
+        "id": "5",
+        "name": "Malaika Muchiri",
+        "img": "/static/media/teamMember2.png",
+        "LinkedIn": "https://www.linkedin.com/in/kimberly-kelsy-926259307",
+        "role": "Tech Team"
+    },
+    {
+        "id": "6",
+        "name": "Malaika Muchiri",
+        "img": "/static/media/teamMember2.png",
+        "LinkedIn": "https://www.linkedin.com/in/kimberly-kelsy-926259307",
+        "role": "Tech Team"
+    }, 
+    {
+        "id": "7",
+        "name": "Malaika Muchiri",
+        "img": "/static/media/teamMember2.png",
+        "LinkedIn": "https://www.linkedin.com/in/kimberly-kelsy-926259307",
+        "role": "Tech Team"
+    },
+    {
+        "id": "8",
+        "name": "Malaika Muchiri",
+        "img": "/static/media/teamMember2.png",
+        "LinkedIn": "https://www.linkedin.com/in/kimberly-kelsy-926259307",
+        "role": "Tech Team"
+    },
+    {
+        "id": "9",
+        "name": "Malaika Muchiri",
+        "img": "/static/media/teamMember2.png",
+        "LinkedIn": "https://www.linkedin.com/in/kimberly-kelsy-926259307",
+        "role": "Tech Team"
+    }  
+]

--- a/freshly_set/frontend/src/components/pages/about-us/json/TeamsData.json
+++ b/freshly_set/frontend/src/components/pages/about-us/json/TeamsData.json
@@ -1,0 +1,23 @@
+[
+    {
+        "id": "1",
+        "name": "Malaika Muchiri",
+        "img": "/static/media/teamMember2.png",
+        "LinkedIn": "https://www.linkedin.com/in/kimberly-kelsy-926259307",
+        "role": "Chief Executive Officer"
+    },
+    {
+        "id": "1",
+        "name": "Malaika Muchiri",
+        "img": "/static/media/teamMember2.png",
+        "LinkedIn": "https://www.linkedin.com/in/kimberly-kelsy-926259307",
+        "role": "Chief Executive Officer"
+    },
+    {
+        "id": "1",
+        "name": "Malaika Muchiri",
+        "img": "/static/media/teamMember2.png",
+        "LinkedIn": "https://www.linkedin.com/in/kimberly-kelsy-926259307",
+        "role": "Chief Executive Officer"
+    }   
+]


### PR DESCRIPTION
I have Updated the Teams section or "Meet our Team" of the about page to incorporate the hovering behaviour on the desktop and the layout.

What has been changed:
- Adding the json files for pulling the data for team member name, image, role and linkedIn link
- Adding the reusable cards for using them in the all team cta page
- Adding json files for ach team category for pulling in data

What is left:
- Combining the separate json files for ach team category for pulling the data from the same file and later on from the database after backend integration 